### PR TITLE
DTCE-3128: Fix discount code import bug

### DIFF
--- a/src/Requests/DiscountNodes/GetDiscountNode.php
+++ b/src/Requests/DiscountNodes/GetDiscountNode.php
@@ -17,7 +17,7 @@ class GetDiscountNode extends QueryRequest
 
   public function graphQuery(): string
   {
-    $titleFilter = sprintf('title:%s', addslashes($this->priceRuleTitle . "*"));
+    $titleFilter = sprintf('title:%s', addslashes($this->priceRuleTitle));
 
     return <<<QUERY
             codeDiscountNodes(first: 1, query: "$titleFilter") {


### PR DESCRIPTION
We want the exact match when fetching the node. Otherwise passing a title like "LDW20" would match to "LDW200".